### PR TITLE
Add buildFlags to default.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ bun2nix.mkBunDerivation {
 
   bunNix = ./bun.nix;
 
+  buildFlags = [
+    "--compile"
+    "--minify"
+    "--sourcemap"
+    "--bytecode"
+  ];
+
   index = ./index.ts;
 }
 ```

--- a/default.nix
+++ b/default.nix
@@ -90,7 +90,6 @@ in {
             --compile \
             --minify \
             --sourcemap \
-            --bytecode \
             ${args.index} \
             --outfile ${name}
 

--- a/default.nix
+++ b/default.nix
@@ -53,6 +53,7 @@ in {
     version,
     src,
     bunNix,
+    buildFlags,
     ...
   } @ args: let
     bunDeps = callPackage bunNix {};
@@ -86,12 +87,7 @@ in {
           runHook preBuild
 
           # Create a bun binary with all the highest compile time optimizations enabled
-          bun build \
-            --compile \
-            --minify \
-            --sourcemap \
-            ${args.index} \
-            --outfile ${name}
+          bun build ${lib.concatStringsSep " " buildFlags} ${args.index} --outfile ${name}
 
           runHook postBuild
         '';


### PR DESCRIPTION
I get errors when building some code with the `--bytecode` flag, so I added a variable `buildFlags` that takes a sequence of user-specified flags to pass to `bun build`. This way, users can choose whether to compile to bytecode, minify, etc.