### PR TITLE
fix(template): add nix build result to gitignore in nix templates

### DIFF
--- a/nix/templates/default/.gitignore
+++ b/nix/templates/default/.gitignore
@@ -1,6 +1,10 @@
 # dependencies (bun install)
 node_modules
 
+# nix
+.direnv
+result
+
 # output
 out
 dist

--- a/nix/templates/react/.gitignore
+++ b/nix/templates/react/.gitignore
@@ -1,6 +1,10 @@
 # dependencies (bun install)
 node_modules
 
+# nix
+.direnv
+result
+
 # output
 out
 dist


### PR DESCRIPTION
This PR adds nix build results to the `.gitignore` file.

These are:
- `.direnv` (dev shell cache)
- `result` (build results generated by nix)