### PR TITLE
Prevent creating urls for workspace references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "bun2nix"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "itertools",

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,36 +1,49 @@
 { pkgs, ... }:
-pkgs.mkShell {
-  packages = with pkgs; [
-    # Rust dependencies
-    rustc
-    cargo
-    rustfmt
-    clippy
-    mold
+pkgs.mkShell (
+  {
+    packages = with pkgs; [
+      # Rust dependencies
+      rustc
+      cargo
+      rustfmt
+      clippy
 
-    # Database
-    sqlx-cli
-    sqlite
+      # Database
+      sqlx-cli
+      sqlite
 
-    # SSL
-    pkg-config
-    openssl
+      # SSL
+      pkg-config
+      openssl
 
-    # Docs
-    mdbook
+      # Docs
+      mdbook
 
-    # Javascript dependencies
-    bun
-  ];
+      # Javascript dependencies
+      bun
+    ];
 
-  env = with pkgs; {
-    RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
-    LD_LIBRARY_PATH = lib.makeLibraryPath [ openssl ];
-    DATABASE_URL = "sqlite://.cache/bun2nix";
-  };
+    env = with pkgs; {
+      LD_LIBRARY_PATH = lib.makeLibraryPath [ openssl ];
+      DATABASE_URL = "sqlite://.cache/bun2nix";
+    };
 
-  shellHook = ''
-    mkdir .cache
-    touch .cache/bun2nix
-  '';
-}
+    shellHook = ''
+      mkdir -p .cache
+      touch .cache/bun2nix
+    '';
+  }
+  # Mold does not support MacOS
+  // (
+    with pkgs;
+    lib.optionalAttrs (!stdenv.isDarwin) {
+      packages = [
+        mold
+      ];
+
+      env = {
+        RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
+      };
+    }
+  )
+)

--- a/nix/templates/workspace/bun.nix
+++ b/nix/templates/workspace/bun.nix
@@ -3,13 +3,13 @@
   "@workspace/app" = {
     out_path = "@workspace/app";
     name = "@workspace/app@workspace:packages/app";
-    url = "https://registry.npmjs.org/@workspace/app/-/app-workspace:packages/app.tgz";
+    url = "";
     hash = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
   };
   "@workspace/lib" = {
     out_path = "@workspace/lib";
     name = "@workspace/lib@workspace:packages/lib";
-    url = "https://registry.npmjs.org/@workspace/lib/-/lib-workspace:packages/lib.tgz";
+    url = "";
     hash = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
   };
   "chalk" = {

--- a/nix/templates/workspace/flake.nix
+++ b/nix/templates/workspace/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
-    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.4.0";
+    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.4.2";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -99,13 +99,27 @@ impl Package<Extracted> {
         Ok(Package {
             data: Normalized {
                 out_path: Normalized::convert_name_to_out_path(&self.name),
-                url: self.to_npm_url()?,
+                // TODO: Larger-scale refactor to remove assumption of npm registry
+                url: if self.is_workspace() {
+                    "".to_string()
+                } else {
+                    self.to_npm_url()?
+                },
                 binaries: self.data.binaries.normalize(&self.name),
             },
             npm_identifier: self.npm_identifier,
             hash: self.hash,
             name: self.name,
         })
+    }
+
+    /// # Workspace detection
+    ///
+    /// Determines whether or not a package is a workspace reference.
+    /// Workspace packages are local references and do not require generated urls.
+    #[inline]
+    pub fn is_workspace(&self) -> bool {
+        self.npm_identifier.contains("workspace")
     }
 }
 


### PR DESCRIPTION
- **chore: support development on macos**
- **fix: prevent generating urls for workspace references**

closes #24

## This PR

Hi there, two little nuggets here:

- enable development on macos
- prevent issues with scopeless workspace packages

## Side note

Ideally it would be great for specifiers to have full compatibility with bun:

- git refs
- path refs
- aliases
- alternative registries

I'm more than happy to collab on making that happen :)
