### PR TITLE
Revert "fix: prevent generating urls for workspace references"

### DIFF
--- a/nix/templates/workspace/bun.nix
+++ b/nix/templates/workspace/bun.nix
@@ -3,13 +3,13 @@
   "@workspace/app" = {
     out_path = "@workspace/app";
     name = "@workspace/app@workspace:packages/app";
-    url = "";
+    url = "https://registry.npmjs.org/@workspace/app/-/app-workspace:packages/app.tgz";
     hash = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
   };
   "@workspace/lib" = {
     out_path = "@workspace/lib";
     name = "@workspace/lib@workspace:packages/lib";
-    url = "";
+    url = "https://registry.npmjs.org/@workspace/lib/-/lib-workspace:packages/lib.tgz";
     hash = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
   };
   "chalk" = {

--- a/src/package.rs
+++ b/src/package.rs
@@ -99,27 +99,13 @@ impl Package<Extracted> {
         Ok(Package {
             data: Normalized {
                 out_path: Normalized::convert_name_to_out_path(&self.name),
-                // TODO: Larger-scale refactor to remove assumption of npm registry
-                url: if self.is_workspace() {
-                    "".to_string()
-                } else {
-                    self.to_npm_url()?
-                },
+                url: self.to_npm_url()?,
                 binaries: self.data.binaries.normalize(&self.name),
             },
             npm_identifier: self.npm_identifier,
             hash: self.hash,
             name: self.name,
         })
-    }
-
-    /// # Workspace detection
-    ///
-    /// Determines whether or not a package is a workspace reference.
-    /// Workspace packages are local references and do not require generated urls.
-    #[inline]
-    pub fn is_workspace(&self) -> bool {
-        self.npm_identifier.contains("workspace")
     }
 }
 


### PR DESCRIPTION
This reverts commit ce183e9fec38ea17bec0341526ef2794431f3390.

My bad, I broke a handful of areas in the derivation builders. Needs a bit more
thought :thinking:
