### PR TITLE
Use flake self-reference in package.nix to improve Nix evaluation per…

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,16 +1,16 @@
 {
-  inputs,
+  flake,
   pkgs,
   ...
 }:
 let
-  cargoTOML = builtins.fromTOML (builtins.readFile (inputs.self + "/Cargo.toml"));
+  cargoTOML = builtins.fromTOML (builtins.readFile (flake + "/Cargo.toml"));
 in
 pkgs.rustPlatform.buildRustPackage {
   pname = cargoTOML.package.name;
   version = cargoTOML.package.version;
 
-  src = inputs.self;
+  src = flake;
 
   buildInputs = with pkgs; [
     pkg-config
@@ -18,7 +18,7 @@ pkgs.rustPlatform.buildRustPackage {
   ];
 
   cargoLock = {
-    lockFile = inputs.self + "/Cargo.lock";
+    lockFile = flake + "/Cargo.lock";
   };
 
   meta = with pkgs.lib; {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,15 +1,16 @@
 {
+  inputs,
   pkgs,
   ...
 }:
 let
-  cargoTOML = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+  cargoTOML = builtins.fromTOML (builtins.readFile (inputs.self + "/Cargo.toml"));
 in
 pkgs.rustPlatform.buildRustPackage {
   pname = cargoTOML.package.name;
   version = cargoTOML.package.version;
 
-  src = ../.;
+  src = inputs.self;
 
   buildInputs = with pkgs; [
     pkg-config
@@ -17,7 +18,7 @@ pkgs.rustPlatform.buildRustPackage {
   ];
 
   cargoLock = {
-    lockFile = ../Cargo.lock;
+    lockFile = inputs.self + "/Cargo.lock";
   };
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
This pull request updates the `nix/package.nix` file to integrate the `inputs` attribute for better compatibility and modularity. The most important changes involve replacing relative paths with paths derived from the `inputs.self` attribute.

### Updates to path handling:

* Replaced the relative path to the `Cargo.toml` file with a path derived from `inputs.self`, ensuring the file is accessed through the `inputs` attribute.
* Updated the `src` attribute to use `inputs.self` instead of a relative path, aligning the source reference with the `inputs` structure.
* Modified the `cargoLock.lockFile` attribute to reference `inputs.self + "/Cargo.lock"` instead of a relative path, standardizing lock file access.

TLDR;;
Replace relative path references (./. | ../) with inputs.self to avoid copying the entire source tree to the store repeatedly. This eliminates the Nix warning from determinant nix and makes evaluation faster.

