### PR TITLE
Evaluate template packages in `nix flake check`

### DIFF
--- a/nix/checks/template-eval-check.nix
+++ b/nix/checks/template-eval-check.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  flake,
+  system,
+  ...
+}:
+let
+  lib = pkgs.lib;
+
+  templates = builtins.attrNames (
+    lib.filterAttrs (_n: v: v == "directory") (builtins.readDir ../templates)
+  );
+
+  evalTemplate =
+    template:
+    pkgs.callPackage (../templates/${template}/default.nix) {
+      inherit (flake.lib.${system}) mkBunDerivation;
+    };
+
+  templatesPkgs = lib.map evalTemplate templates;
+in
+pkgs.symlinkJoin {
+  name = "template-eval-check";
+  paths = templatesPkgs;
+}


### PR DESCRIPTION
Adds a check script to automatically find any templates that exist and evaluate them to see if `mkBunDerivation` continues to work.