### PR TITLE
fix(nix): make nativeBuildInputs extend from arg

### DIFF
--- a/nix/lib/mkBunDerivation.nix
+++ b/nix/lib/mkBunDerivation.nix
@@ -19,6 +19,7 @@
   workspaceRoot ? null, # Root directory containing all workspace packages
   workspaces ? { }, # Map of package name to source directory
   dontPatchShebangs ? false,
+  nativeBuildInputs ? [ ],
   ...
 }@args:
 assert lib.assertMsg (args ? pname || args ? packageJson)
@@ -55,11 +56,6 @@ stdenv.mkDerivation (
   {
     inherit (pkgInfo) pname version;
     inherit src;
-
-    nativeBuildInputs = [
-      rsync
-      bun
-    ];
 
     # Load node_modules based on the expression generated from the lockfile
     configurePhase = ''
@@ -170,4 +166,10 @@ stdenv.mkDerivation (
     };
   }
   // args
+  // {
+    nativeBuildInputs = nativeBuildInputs ++ [
+      rsync
+      bun
+    ];
+  }
 )


### PR DESCRIPTION
This PR fixes a regression in `mkBunDerivation`.

Before, when specifying additional dependencies in `nativeBuildInputs` (for example: `makeWrapper`), this derivation would break since the `nativeBuildInputs` specified by the implementation of `mkBunDerivation` would get overridden.
This throws errors like `rsync: command not found`. This PR fixes this by appending `nativeBuildInputs` from `args` instead of overriding.

Now, I know this is not the cleanest solution. I highly advise `mkBunDerivation` gets migrated to something like [lib.extendMkDerivation](https://noogle.dev/f/lib/extendMkDerivation).
I can assist with this if you want. I'll keep this your desicion, of course.
