### PR TITLE
chore(nix)!: use lib.extendMkDerivation

### DIFF
--- a/nix/lib/mkBunDerivation.nix
+++ b/nix/lib/mkBunDerivation.nix
@@ -1,175 +1,170 @@
 {
-  bun,
   lib,
   mkBunNodeModules,
-  rsync,
   stdenv,
+  bun,
+  rsync,
   ...
 }:
-{
-  src,
-  bunNix,
-  buildFlags ? [
-    "--compile"
-    "--minify"
-    "--sourcemap"
-    "--bytecode"
-  ],
-  # New fields for workspace support
-  workspaceRoot ? null, # Root directory containing all workspace packages
-  workspaces ? { }, # Map of package name to source directory
-  dontPatchShebangs ? false,
-  nativeBuildInputs ? [ ],
-  ...
-}@args:
-assert lib.assertMsg (args ? pname || args ? packageJson)
-  "Either `pname` or `packageJson` must be set in order to assign a name to the package. It may be assigned manually with `pname` which always takes priority or read from the `name` field of `packageJson`.";
-assert lib.assertMsg (args ? version || args ? packageJson)
-  "Either `version` or `packageJson` must be set in order to assign a version to the package. It may be assigned manually with `version` which always takes priority or read from the `version` field of `packageJson`.";
-let
-  packages = import bunNix;
-  bunDeps = mkBunNodeModules { inherit packages dontPatchShebangs; };
 
-  # Check if there are workspace packages
-  hasWorkspaces = lib.any (pkg: lib.strings.hasInfix "workspace:" pkg.url) (lib.attrValues packages);
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "packageJson"
+    "index"
+    "bunNix"
+    "workspaceRoot"
+    "workspaces"
+  ];
+  extendDrvArgs = (
+    _finalAttrs:
+    {
+      packageJson ? null,
+      bunNix,
+      workspaceRoot ? null,
+      workspaces ? { },
+      dontPatchShebangs ? false,
+      nativeBuildInputs ? [ ],
+      buildFlags ? [
+        "--compile"
+        "--minify"
+        "--sourcemap"
+        "--bytecode"
+      ],
+      # Bun binaries built by this derivation become broken by the default fixupPhase
+      dontFixup ? !(args ? buildPhase),
+      ...
+    }@args:
 
-  pkgInfo =
-    if args ? packageJson then
-      let
-        packageJson = builtins.fromJSON (builtins.readFile args.packageJson);
-      in
-      assert lib.assertMsg (packageJson ? name && packageJson ? version && packageJson ? module)
-        "In order to use a package.json to fill the `pname`, `version` and `index` fields of mkBunDerivation it must at least contain the fields `name`, `version` and `module`.";
-      {
-        pname = args.pname or packageJson.name;
-        version = args.version or packageJson.version;
-        index = args.index or packageJson.module;
-      }
-    else
-      {
-        pname = args.pname;
-        version = args.version;
-        index = args.index;
-      };
-in
-stdenv.mkDerivation (
-  {
-    inherit (pkgInfo) pname version;
-    inherit src;
+    assert lib.assertMsg (args ? pname || packageJson != null)
+      "mkBunDerivation: Either `pname` or `packageJson` must be set in order to assign a name to the package. It may be assigned manually with `pname` which always takes priority or read from the `name` field of `packageJson`.";
 
-    # Load node_modules based on the expression generated from the lockfile
-    configurePhase = ''
-      runHook preConfigure
+    assert lib.assertMsg (args ? version || packageJson != null)
+      "mkBunDerivation: Either `version` or `packageJson` must be set in order to assign a version to the package. It may be assigned manually with `version` which always takes priority or read from the `version` field of `packageJson`.";
 
-      # Unfortunately a full copy of node_modules does need to be done instead of a symlink as many packages will write to their install location
-      rsync -a --copy-links --chmod=ugo+w --exclude=".bin" ${bunDeps}/node_modules/ ./node_modules/
+    let
+      packages = import bunNix;
+      hasWorkspaces = lib.any (pkg: lib.strings.hasInfix "workspace:" pkg.url) (lib.attrValues packages);
+      bunDeps = mkBunNodeModules { inherit packages dontPatchShebangs; };
 
-      # Preserve symlinks in .bin
-      if [ -d "${bunDeps}/node_modules/.bin" ]; then
-        rsync -a --links ${bunDeps}/node_modules/.bin/ ./node_modules/.bin/
-      fi
+      package = if packageJson != null then (builtins.fromJSON (builtins.readFile packageJson)) else { };
 
-      # Handle workspace packages automatically if present
-      ${lib.optionalString hasWorkspaces ''
-        echo "Setting up workspace packages..."
-      ''}
+      pname = args.pname or package.name or null;
+      version = args.version or package.version or null;
+      index = args.index or package.module or null;
+    in
 
-      # Setup workspace packages if workspaceRoot is provided
-      ${lib.optionalString (hasWorkspaces && workspaceRoot != null) ''
-        # Loop through all packages to detect workspace packages and link them
-        ${lib.concatStrings (
-          lib.mapAttrsToList (
-            name: pkg:
-            if !(lib.strings.hasInfix "workspace:" pkg.url) then
-              ""
-            else
-              let
-                workspacePath = builtins.replaceStrings [ "workspace:" ] [ "" ] pkg.url;
-              in
-              ''
-                # Extract workspace identifier from npm identifier
-                echo "Linking workspace package ${name} from ${workspaceRoot}/${workspacePath}"
-                mkdir -p $(dirname "node_modules/${pkg.out_path}")
+    assert lib.assertMsg (pname != null)
+      "mkBunDerivation: Either `name` must be specified in the given `packageJson` file, or passed as the `name` argument";
 
-                if [ -d "${workspaceRoot}/${workspacePath}" ]; then
-                  # Primary path exists, use it
-                  rsync -a --copy-links "${workspaceRoot}/${workspacePath}/" "node_modules/${pkg.out_path}/"
+    assert lib.assertMsg (version != null)
+      "mkBunDerivation: Either `version` must be specified in the given `packageJson` file, or passed as the `version` argument";
+
+    {
+      inherit
+        pname
+        version
+        dontFixup
+        dontPatchShebangs
+        ;
+
+      configurePhase =
+        args.configurePhase or ''
+          runHook preConfigure
+
+          # Unfortunately a full copy of node_modules does need to be done instead of a symlink as many packages will write to their install location
+          rsync -a --copy-links --chmod=ugo+w --exclude=".bin" ${bunDeps}/node_modules/ ./node_modules/
+
+          # Preserve symlinks in .bin
+          if [ -d "${bunDeps}/node_modules/.bin" ]; then
+            rsync -a --links ${bunDeps}/node_modules/.bin/ ./node_modules/.bin/
+          fi
+
+          # Handle workspace packages automatically if present
+          ${lib.optionalString hasWorkspaces ''
+            echo "Setting up workspace packages..."
+          ''}
+
+          # Setup workspace packages if workspaceRoot is provided
+          ${lib.optionalString (hasWorkspaces && workspaceRoot != null) ''
+            # Loop through all packages to detect workspace packages and link them
+            ${lib.concatStrings (
+              lib.mapAttrsToList (
+                name: pkg:
+                if !(lib.strings.hasInfix "workspace:" pkg.url) then
+                  ""
                 else
-                  echo "Warning: Workspace package ${name} directory not found at ${workspaceRoot}/${workspacePath}"
+                  let
+                    workspacePath = builtins.replaceStrings [ "workspace:" ] [ "" ] pkg.url;
+                  in
+                  ''
+                    # Extract workspace identifier from npm identifier
+                    echo "Linking workspace package ${name} from ${workspaceRoot}/${workspacePath}"
+                    mkdir -p $(dirname "node_modules/${pkg.out_path}")
 
-                  # Fallback to common workspace paths
-                  SIMPLE_NAME=$(echo "${name}" | sed -e 's|^@[^/]*/||')
-
-                  if [ -d "${workspaceRoot}/packages/$SIMPLE_NAME" ]; then
-                    echo "Found alternative at ${workspaceRoot}/packages/$SIMPLE_NAME"
-                    rsync -a --copy-links "${workspaceRoot}/packages/$SIMPLE_NAME/" "node_modules/${pkg.out_path}/"
-                  else
-                    if [ -d "${workspaceRoot}/$SIMPLE_NAME" ]; then
-                      echo "Found alternative at ${workspaceRoot}/$SIMPLE_NAME"
-                      rsync -a --copy-links "${workspaceRoot}/$SIMPLE_NAME/" "node_modules/${pkg.out_path}/"
+                    if [ -d "${workspaceRoot}/${workspacePath}" ]; then
+                      # Primary path exists, use it
+                      rsync -a --copy-links "${workspaceRoot}/${workspacePath}/" "node_modules/${pkg.out_path}/"
                     else
-                      echo "Could not find workspace package directory"
+                      echo "Warning: Workspace package ${name} directory not found at ${workspaceRoot}/${workspacePath}"
+
+                      # Fallback to common workspace paths
+                      SIMPLE_NAME=$(echo "${name}" | sed -e 's|^@[^/]*/||')
+
+                      if [ -d "${workspaceRoot}/packages/$SIMPLE_NAME" ]; then
+                        echo "Found alternative at ${workspaceRoot}/packages/$SIMPLE_NAME"
+                        rsync -a --copy-links "${workspaceRoot}/packages/$SIMPLE_NAME/" "node_modules/${pkg.out_path}/"
+                      else
+                        if [ -d "${workspaceRoot}/$SIMPLE_NAME" ]; then
+                          echo "Found alternative at ${workspaceRoot}/$SIMPLE_NAME"
+                          rsync -a --copy-links "${workspaceRoot}/$SIMPLE_NAME/" "node_modules/${pkg.out_path}/"
+                        else
+                          echo "Could not find workspace package directory"
+                        fi
+                      fi
                     fi
-                  fi
-                fi
-              ''
-          ) packages
-        )}
-      ''}
+                  ''
+              ) packages
+            )}
+          ''}
 
-      # Setup explicitly provided workspaces
-      ${lib.concatStrings (
-        lib.mapAttrsToList (name: path: ''
-          echo "Linking workspace package ${name} from ${path}"
-          mkdir -p $(dirname "node_modules/${name}")
-          rsync -a --copy-links "${path}/" "node_modules/${name}/"
-        '') workspaces
-      )}
+          # Setup explicitly provided workspaces
+          ${lib.concatStrings (
+            lib.mapAttrsToList (name: path: ''
+              echo "Linking workspace package ${name} from ${path}"
+              mkdir -p $(dirname "node_modules/${name}")
+              rsync -a --copy-links "${path}/" "node_modules/${name}/"
+            '') workspaces
+          )}
 
-      mkdir tmp
-      export HOME=$TMPDIR
+          mkdir tmp
+          export HOME=$TMPDIR
 
-      runHook postConfigure
-    '';
+          runHook postConfigure
+        '';
 
-    # Create a react static html site as per the script
-    buildPhase =
-      assert lib.assertMsg (pkgInfo ? index)
-        "`index` input to `mkBunDerivation` pointing to your javascript index file must be set in order to use the default buildPhase. This may also be inferred from the `module` field of `packageJson`";
-      assert lib.assertMsg (lib.isString pkgInfo.index)
-        "`index` (or the module field of packageJson) should be a string value pointing to your index file from the root of your repository. If you use a nix path here (./index.ts (BAD) vs 'index.ts'(GOOD)) this will not be able to resolve dependencies correctly as the path version will be copied to the nix store separately";
-      ''
-        runHook preBuild
+      buildPhase =
+        args.buildPhase or (
+          assert lib.assertMsg (builtins.isString index)
+            "mkBunDerivation: to use the default buildPhase, either `module` must be specified in the given `packageJson` file, or passed as the `index` argument, and it should not be a nix store path, but a path relative to the workspace directory";
+          ''
+            runHook preBuild
+            bun build ${lib.concatStringsSep " " buildFlags} ${index} --outfile ${pname}
+            runHook postBuild
+          ''
+        );
 
-        bun build ${lib.concatStringsSep " " buildFlags} ${pkgInfo.index} --outfile ${pkgInfo.pname}
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
+          install -Dm755 ${pname} $out/bin/${pname}
+          runHook postInstall
+        '';
 
-        runHook postBuild
-      '';
-
-    # Install the binary to the output folder
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/bin
-
-      cp ./${pkgInfo.pname} $out/bin
-
-      runHook postInstall
-    '';
-
-    # Bun binaries are broken by fixup phase
-    dontFixup = true;
-  }
-  // lib.optionalAttrs (!(args ? buildPhase) && !(args ? installPhase)) {
-    meta = {
-      mainProgram = pkgInfo.pname;
-    };
-  }
-  // args
-  // {
-    nativeBuildInputs = nativeBuildInputs ++ [
-      rsync
-      bun
-    ];
-  }
-)
+      nativeBuildInputs = nativeBuildInputs ++ [
+        rsync
+        bun
+      ];
+    }
+  );
+}


### PR DESCRIPTION
See: https://github.com/baileyluTCD/bun2nix/pull/37

There are a few minor behavior changes; now
- it is no longer neccesary to specify an `index` file if there is a custom `buildPhase`
- the `fixupPhase` only gets skipped by default if there is no custom `buildPhase`
- the `dontPatchShebangs` argument now gets honored by the entire derivation, not just the `bunDeps`
