### PR TITLE
Patch local script shebangs before build

### DIFF
--- a/nix/lib/mkBunDerivation.nix
+++ b/nix/lib/mkBunDerivation.nix
@@ -68,9 +68,16 @@ lib.extendMkDerivation {
         dontPatchShebangs
         ;
 
-      preConfigurePhases = args.preConfigurePhases or [
-        "installNodeModulesPhase"
-      ];
+      preConfigurePhases =
+        args.preConfigurePhases or [
+          "preNodeModulesInstallFixupPhase"
+          "installNodeModulesPhase"
+        ];
+
+      preNodeModulesInstallFixupPhase =
+        args.preNodeModulesInstallFixupPhase or ''
+          patchShebangs .
+        '';
 
       installNodeModulesPhase =
         args.installNodeModulesPhase or ''


### PR DESCRIPTION
Shebangs of local scripts i.e

```js
#!/usr/bin/env bun
```

Should be patched up before building.

NOTE: This PR additionally renames the phase in which node_modules are installed in light of switching to `lib.extendMkDerivation`.