### PR TITLE
fix(devshell): attrs now properly merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rinja = "0.3.5"
 
 [package]
 name = "bun2nix"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 
 [profile.release]

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,49 +1,48 @@
 { pkgs, ... }:
 pkgs.mkShell (
+  let
+    # Mold does not support MacOS
+    enableMold = !pkgs.stdenv.isDarwin;
+  in
   {
-    packages = with pkgs; [
-      # Rust dependencies
-      rustc
-      cargo
-      rustfmt
-      clippy
+    packages =
+      with pkgs;
+      [
+        # Rust dependencies
+        rustc
+        cargo
+        rustfmt
+        clippy
 
-      # Database
-      sqlx-cli
-      sqlite
+        # Database
+        sqlx-cli
+        sqlite
 
-      # SSL
-      pkg-config
-      openssl
+        # SSL
+        pkg-config
+        openssl
 
-      # Docs
-      mdbook
+        # Docs
+        mdbook
 
-      # Javascript dependencies
-      bun
-    ];
+        # Javascript dependencies
+        bun
+      ]
+      ++ pkgs.lib.optional enableMold pkgs.mold;
 
-    env = with pkgs; {
-      LD_LIBRARY_PATH = lib.makeLibraryPath [ openssl ];
-      DATABASE_URL = "sqlite://.cache/bun2nix";
-    };
+    env =
+      with pkgs;
+      {
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ openssl ];
+        DATABASE_URL = "sqlite://.cache/bun2nix";
+      }
+      // lib.optionalAttrs enableMold {
+        RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
+      };
 
     shellHook = ''
       mkdir -p .cache
       touch .cache/bun2nix
     '';
   }
-  # Mold does not support MacOS
-  // (
-    with pkgs;
-    lib.optionalAttrs (!stdenv.isDarwin) {
-      packages = [
-        mold
-      ];
-
-      env = {
-        RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
-      };
-    }
-  )
 )

--- a/nix/templates/default/flake.nix
+++ b/nix/templates/default/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.1";
+    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.2";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/nix/templates/react/flake.nix
+++ b/nix/templates/react/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.1";
+    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.2";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/nix/templates/workspace/flake.nix
+++ b/nix/templates/workspace/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
-    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.1";
+    bun2nix.url = "github:baileyluTCD/bun2nix?tag=1.5.2";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
# Describe the issue
It has not properly merged devshell's attrset argument, resulting in (probably) unintended devshell.

```sh
# on linux, in this flake's devshell
which bun
# -> which: no bun in $PATH

printenv DATABASE_URL
# (exit with 1, env not found)
```

it's because `//` operator overrides attribute values if RHS and LHS both have same attribute, instead of merging them like nix module systems do.

```nix
{
  foo = [ 1 ];
} // {
  foo = [ 2 ];
}
# -> { foo = [ 2 ]; }
```

# Solution

configure optional dependencies inline.

```nix
{
  foo = [ 1 ] ++ [ 2 ];
}
```

# Notes

let me know if the behavior was intended, in which case I will write it in a way it is more clear that it is intended.