### PR TITLE
build off of other overlays to allow overriding bun version

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -5,10 +5,10 @@
   ];
 
   perSystem =
-    { self', ... }:
+    { config, ... }:
     {
       overlayAttrs = {
-        inherit (self'.packages) bun2nix;
+        inherit (config.packages) bun2nix;
       };
     };
 }


### PR DESCRIPTION
Thanks for this very helpful project! It's working pretty smoothly for me. Except that I'm trying to package an app that is adamant that it needs to run with bun v1.2.2. I've looked through the documentation and some of the repo code, and I don't see anything about overriding the bun version. To me it seems like the natural way to do it is to use an overlay in my consuming flake like this:

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    systems.url = "github:nix-systems/default";
    bun2nix = { url = "github:nix-community/bun2nix"; inputs.nixpkgs.follows = "nixpkgs"; };
    bunnix = { url = "github:aster-void/bunnix"; inputs.nixpkgs.follows = "nixpkgs"; };
  };

  outputs = { self, nixpkgs, systems, ... }@inputs:
    let
    overlays = [
      (final: prev: {
        bun = inputs.bunnix.lib.${final.stdenv.hostPlatform.system}.fromBunVersionFile ./.bun-version;
      })
      inputs.bun2nix.overlays.default
    ];
      mkPkgs = localSystem: import nixpkgs { inherit localSystem overlays; };
      perSystem = callback: nixpkgs.lib.genAttrs (import systems) (system: callback (mkPkgs system));
    in
    {
      packages = perSystem (pkgs: {
        default = pkgs.bun2nix.mkDerivation {
          packageJson = ./package.json;
          src = builtins.path { path = ./.; name = "my-app-source"; };
          bunDeps = pkgs.bun2nix.fetchBunDeps { bunNix = ./bun.nix; };
          module = "index.ts";
        };
      });
    };
}
```

Unfortunately that doesn't work currently because the bun2nix packages do not reference overlay package sets. But the one tiny change in this PR fixes that.

There is still an issue that the overlay that is produced is order-dependent. If I swap the order of the overlays in the example above then I get the wrong bun version. I think this is an upstream problem with flake-parts - see https://github.com/hercules-ci/flake-parts/issues/327. It's possible to create on overlay that is not order-dependent without upstream changes with one of these options:

1. Change uses of `pkgs` to `final` basically everywhere in the flake.
2. Replace the easyModule import with a modified version as described in https://github.com/hercules-ci/flake-parts/issues/327.
3. Separate package definitions from flake-parts module code, creating a module for each package to be invoked with `callPackage`.

I don't know if you will be motivated to bother with any of those options, so I'm submitting this PR without any order-dependency fixes.