### PR TITLE
Fix parsing local tarball dependencies

### DIFF
--- a/nix/checks/arbitrary-install-completes.nix
+++ b/nix/checks/arbitrary-install-completes.nix
@@ -6,7 +6,7 @@
       checks.arbitraryInstallCompletes = pkgs.stdenv.mkDerivation {
         name = "bun2nix-exec-test";
 
-        outputHash = "sha256-GoSIjTviHvKwApXYivLwwVMPvp32fqgqpSxlLGpBgUg=";
+        outputHash = "sha256-mYoND6xD+uEgKjq17hDWPe5pEEnwmSNfHPCqE4R+B5E=";
         outputHashAlgo = "sha256";
         outputHashMode = "recursive";
 
@@ -17,10 +17,16 @@
           cacert
           git
           nixfmt
+          gnutar
+          gzip
         ];
 
         installPhase = ''
           PWD="$(pwd)"
+
+          # Create local tarball for testing bun2nix's handling of local tarballs
+          # without file: prefix (Bun strips it in the packages section).
+          bash ./local-tarball/setup.sh
 
           export NIX_STATE_DIR=$PWD/nix-state
           export NIX_STORE_DIR=$PWD/nix-store

--- a/nix/checks/arbitrary-install-completes/test-project/README.md
+++ b/nix/checks/arbitrary-install-completes/test-project/README.md
@@ -3,6 +3,7 @@
 To install dependencies:
 
 ```bash
+./local-tarball/setup.sh
 bun install
 ```
 

--- a/nix/checks/arbitrary-install-completes/test-project/bun.lock
+++ b/nix/checks/arbitrary-install-completes/test-project/bun.lock
@@ -21,81 +21,26 @@
     },
   },
   "packages": {
-    "@gitlab-examples/semantic-release-npm": [
-      "@gitlab-examples/semantic-release-npm@git+https://gitlab.com/gitlab-examples/semantic-release-npm#ee100d81f12ae315a81c2a664979a6cc1bce99a2",
-      {},
-      "ee100d81f12ae315a81c2a664979a6cc1bce99a2"
-    ],
-    "@types/bun": [
-      "@types/bun@1.3.3",
-      "",
-      {
-        "dependencies": {
-          "bun-types": "1.3.3"
-        }
-      },
-      "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="
-    ],
-    "@types/node": [
-      "@types/node@24.10.1",
-      "",
-      {
-        "dependencies": {
-          "undici-types": "~7.16.0"
-        }
-      },
-      "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="
-    ],
-    "bun-types": [
-      "bun-types@1.3.3",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="
-    ],
-    "dayjs": [
-      "dayjs@github:iamkun/dayjs#45bf6a3",
-      {},
-      "iamkun-dayjs-45bf6a3"
-    ],
-    "react": [
-      "react@19.2.0",
-      "",
-      {},
-      "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="
-    ],
-    "test-project-file-dep": [
-      "test-project-file-dep@file:file-dep",
-      {}
-    ],
-    "typescript": [
-      "typescript@5.9.3",
-      "",
-      {
-        "bin": {
-          "tsc": "bin/tsc",
-          "tsserver": "bin/tsserver"
-        }
-      },
-      "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
-    ],
-    "undici-types": [
-      "undici-types@7.16.0",
-      "",
-      {},
-      "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
-    ],
-    "zod": [
-      "zod@github:colinhacks/zod#7dbf404",
-      {},
-      "colinhacks-zod-7dbf404"
-    ],
-    "zod-tarball": [
-      "zod@https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      {}
-    ],
+    "@gitlab-examples/semantic-release-npm": ["@gitlab-examples/semantic-release-npm@git+https://gitlab.com/gitlab-examples/semantic-release-npm#ee100d81f12ae315a81c2a664979a6cc1bce99a2", {}, "ee100d81f12ae315a81c2a664979a6cc1bce99a2"],
+
+    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+
+    "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
+    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+
+    "dayjs": ["dayjs@github:iamkun/dayjs#45bf6a3", {}, "iamkun-dayjs-45bf6a3"],
+
+    "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
+
+    "test-project-file-dep": ["test-project-file-dep@file:file-dep", {}],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "zod": ["zod@github:colinhacks/zod#7dbf404", {}, "colinhacks-zod-7dbf404"],
+
+    "zod-tarball": ["zod@https://registry.npmjs.org/zod/-/zod-3.21.4.tgz", {}],
   }
 }

--- a/nix/checks/arbitrary-install-completes/test-project/bun.lock
+++ b/nix/checks/arbitrary-install-completes/test-project/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@gitlab-examples/semantic-release-npm": "https://gitlab.com/gitlab-examples/semantic-release-npm",
         "dayjs": "git+https://github.com/iamkun/dayjs.git",
+        "local-tarball-dep": "file:./local-tarball/dep-1.0.0.tgz",
         "react": "^19",
         "test-project-file-dep": "./file-dep",
         "zod": "github:colinhacks/zod",
@@ -30,6 +31,8 @@
     "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
 
     "dayjs": ["dayjs@github:iamkun/dayjs#45bf6a3", {}, "iamkun-dayjs-45bf6a3"],
+
+    "local-tarball-dep": ["local-tarball-dep@./local-tarball/dep-1.0.0.tgz", {}],
 
     "react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
 

--- a/nix/checks/arbitrary-install-completes/test-project/local-tarball/setup.sh
+++ b/nix/checks/arbitrary-install-completes/test-project/local-tarball/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Creates the local tarball dependency for testing bun2nix's handling of
+# local tarballs without file: prefix (Bun strips it in the packages section).
+# Run this before `bun install` in the test-project directory.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+mkdir -p tarball-src/package
+echo '{"name":"local-tarball-dep","version":"1.0.0"}' >tarball-src/package/package.json
+tar -czf dep-1.0.0.tgz -C tarball-src package
+rm -rf tarball-src
+
+echo "Created local-tarball/dep-1.0.0.tgz"

--- a/nix/checks/arbitrary-install-completes/test-project/package.json
+++ b/nix/checks/arbitrary-install-completes/test-project/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@gitlab-examples/semantic-release-npm": "https://gitlab.com/gitlab-examples/semantic-release-npm",
+    "local-tarball-dep": "file:./local-tarball/dep-1.0.0.tgz",
     "dayjs": "git+https://github.com/iamkun/dayjs.git",
     "react": "^19",
     "test-project-file-dep": "./file-dep",

--- a/programs/bun2nix/src/lockfile/package_deserializer.rs
+++ b/programs/bun2nix/src/lockfile/package_deserializer.rs
@@ -172,15 +172,35 @@ impl PackageDeserializer {
     /// Deserialize a file package from it's bun lockfile representation
     ///
     /// This is found in the source as a tuple of arity 2
+    ///
+    /// Handles both explicit `file:` prefix and inferred local paths.
+    /// Bun strips the `file:` prefix for local tarballs in the packages section,
+    /// so we need to infer local paths from `./` prefixes.
+    ///
+    /// See:
+    /// - https://github.com/oven-sh/bun/blob/7ebfdf97a872908aeacce7af7eba21658b265ad7/src/install/dependency.zig#L514-L517
+    /// - https://github.com/oven-sh/bun/blob/7ebfdf97a872908aeacce7af7eba21658b265ad7/src/install/resolution.zig#L46-L59
     pub fn deserialize_file_package(name: String, path: String) -> Result<Package> {
         debug_assert!(
             !path.contains("http"),
             "File path can never contain http, because then it would be a tarball"
         );
 
-        let path = Self::drain_after_substring(path, "file:").ok_or(Error::MissingFileSpecifier)?;
+        if let Some(stripped) = Self::drain_after_substring(path.clone(), "file:") {
+            return Ok(Package::new(name, Fetcher::CopyToStore { path: stripped }));
+        }
 
-        Ok(Package::new(name, Fetcher::CopyToStore { path }))
+        // Strip ./ prefix since the template adds it back
+        if let Some(stripped) = path.strip_prefix("./") {
+            return Ok(Package::new(
+                name,
+                Fetcher::CopyToStore {
+                    path: stripped.to_string(),
+                },
+            ));
+        }
+
+        Err(Error::MissingFileSpecifier)
     }
 
     /// # Deserialize a tarball package

--- a/programs/bun2nix/src/lockfile/package_deserializer.rs
+++ b/programs/bun2nix/src/lockfile/package_deserializer.rs
@@ -186,21 +186,18 @@ impl PackageDeserializer {
             "File path can never contain http, because then it would be a tarball"
         );
 
-        if let Some(stripped) = Self::drain_after_substring(path.clone(), "file:") {
-            return Ok(Package::new(name, Fetcher::CopyToStore { path: stripped }));
-        }
+        // Strip prefix: explicit "file:" or implicit "./" (Bun strips file: for local tarballs)
+        let path = path
+            .strip_prefix("file:")
+            .or_else(|| path.strip_prefix("./"))
+            .ok_or(Error::MissingFileSpecifier)?;
 
-        // Strip ./ prefix since the template adds it back
-        if let Some(stripped) = path.strip_prefix("./") {
-            return Ok(Package::new(
-                name,
-                Fetcher::CopyToStore {
-                    path: stripped.to_string(),
-                },
-            ));
-        }
-
-        Err(Error::MissingFileSpecifier)
+        Ok(Package::new(
+            name,
+            Fetcher::CopyToStore {
+                path: path.to_string(),
+            },
+        ))
     }
 
     /// # Deserialize a tarball package


### PR DESCRIPTION
## Summary

Fixes bun2nix failing with `MissingFileSpecifier` error when parsing local tarball dependencies.

## The Problem

When you specify a local tarball with `file:` prefix in `package.json`:

```json
{
  "dependencies": {
    "my-local-pkg": "file:./vendor/my-local-pkg-1.0.0.tgz"
  }
}
```

Bun preserves the prefix in `workspaces` but strips it in `packages`:

```json
{
  "workspaces": {
    "": {
      "dependencies": {
        "my-local-pkg": "file:./vendor/my-local-pkg-1.0.0.tgz"  // `file:` preserved
      }
    }
  },
  "packages": {
    "my-local-pkg": ["my-local-pkg@./vendor/my-local-pkg-1.0.0.tgz", {}]  // `file:` stripped
  }
}
```

bun2nix previously strictly required the `file:` prefix when parsing `packages`. This PR brings bun2nix's behavior closer to Bun's when parsing such deps.

## Bun's inconsistent behavior

Bun treats `.folder` and `.local_tarball` differently when writing the lockfile:

- `./file-dep` -> `test-project-file-dep@file:file-dep`
- `file:./local-tarball/dep-1.0.0.tgz` -> `local-tarball-dep@./local-tarball/dep-1.0.0.tgz`

Relevant Bun source:
- [bun.lock.zig#L494-L498](https://github.com/oven-sh/bun/blob/7ebfdf97a872908aeacce7af7eba21658b265ad7/src/install/lockfile/bun.lock.zig#L494-L498)
- [bun.lock.zig#L517-L521](https://github.com/oven-sh/bun/blob/7ebfdf97a872908aeacce7af7eba21658b265ad7/src/install/lockfile/bun.lock.zig#L517-L521)
- [resolution.zig#L46-L59](https://github.com/oven-sh/bun/blob/7ebfdf97a872908aeacce7af7eba21658b265ad7/src/install/resolution.zig#L46-L59)

I'm not sure if this inconsistency is intentional or a bug/oversight.
Nevertheless, Bun handles this fine via falling back on inference from `./`.

## The Fix

Infers local paths from `./` prefix when `file:` is absent, matching Bun's `Dependency.Version.Tag.infer()` behavior.

## Test Approach

The test uses a `setup.sh` script to create the tarball dynamically rather than committing a `.tgz` file in order to keep the test contents transparent.

Trade-off: `bun install` in the test project requires `./local-tarball/setup.sh` first, but presumably test deps rarely change so the added friction seems acceptable.
