### PR TITLE
Replace tag with ref in GitHub fetcher URLs

### DIFF
--- a/nix/checks/template-version-check.nix
+++ b/nix/checks/template-version-check.nix
@@ -28,7 +28,7 @@
 
             version=$(
               cat "${templatesDir}/$template/flake.nix" | \
-              grep -Po 'bun2nix\.url = "github:nix-community/bun2nix\?tag=\K[0-9]+\.[0-9]+\.[0-9]+'
+              grep -Po 'bun2nix\.url = "github:nix-community/bun2nix\?ref=\K[0-9]+\.[0-9]+\.[0-9]+'
             )
 
             if ! [[ "$version" == "${currentVersion}" ]]; then

--- a/nix/deprecations.nix
+++ b/nix/deprecations.nix
@@ -15,7 +15,7 @@ let
 
       ```nix
       # Put the appropriate version here
-      bun2nix.url = "github:nix-community/bun2nix?tag=2.0.0";
+      bun2nix.url = "github:nix-community/bun2nix?ref=2.0.0";
       ```
 
       # Potential Fix:

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/git-deps/flake.nix
+++ b/templates/git-deps/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/nextjs/flake.nix
+++ b/templates/nextjs/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/overrides/flake.nix
+++ b/templates/overrides/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/patched-deps/flake.nix
+++ b/templates/patched-deps/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/phoenix/flake.nix
+++ b/templates/phoenix/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/private-registry/flake.nix
+++ b/templates/private-registry/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/react/flake.nix
+++ b/templates/react/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/tarball-deps/flake.nix
+++ b/templates/tarball-deps/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };

--- a/templates/workspace/flake.nix
+++ b/templates/workspace/flake.nix
@@ -6,7 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     systems.url = "github:nix-systems/default";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix?ref=2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
     bun2nix.inputs.systems.follows = "systems";
   };


### PR DESCRIPTION
`tag` is not a valid URL param for the GitHub nix fetcher, causing it to silently fall back to the default branch. This will be an error in a future version of nix.

https://github.com/NixOS/nix/pull/15331